### PR TITLE
The primary key is not necessarily `id`

### DIFF
--- a/django_fsm_log/managers.py
+++ b/django_fsm_log/managers.py
@@ -12,7 +12,7 @@ class StateLogQuerySet(QuerySet):
     def for_(self, obj):
         return self.filter(
             content_type=self._get_content_type(obj),
-            object_id=obj.id
+            object_id=obj.pk
         )
 
 


### PR DESCRIPTION
Use `pk` alias instead.

Motivated by usage of UUIDField as pk, for my models.
