### PR TITLE
Fixed get_state_display issue in StateLog

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -83,10 +83,19 @@ class StateLogModelTests(TestCase):
 
     def test_get_display_state(self):
         self.article.submit()
+        self.article.save()
 
-        log = StateLog.objects.all()[0]
+        log = StateLog.objects.latest()
         article = Article.objects.get(pk=self.article.pk)
         self.assertEqual(log.get_state_display(), article.get_state_display())
+
+        self.article.publish()
+        self.article.save()
+
+        log = StateLog.objects.all()[0]
+
+        article = Article.objects.get(pk=self.article.pk)
+        self.assertNotEqual(log.get_state_display(), article.get_state_display())
 
 
 class StateLogManagerTests(TestCase):


### PR DESCRIPTION
I introduced a bug. The get_state_display will display the current state of the content_object rather then the state of the log.
This is fixed now.