### PR TITLE
Get rid of RemovedInDjango19Warnings

### DIFF
--- a/django_fsm_log/apps.py
+++ b/django_fsm_log/apps.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from django.apps import AppConfig
 from django.conf import settings
-from django.utils.module_loading import import_by_path
+from django.utils.module_loading import import_string
 
 from django_fsm.signals import pre_transition, post_transition
 
@@ -11,7 +11,7 @@ class DjangoFSMLogAppConfig(AppConfig):
     verbose_name = "Django FSM Log"
 
     def ready(self):
-        backend = import_by_path(settings.DJANGO_FSM_LOG_STORAGE_METHOD)
+        backend = import_string(settings.DJANGO_FSM_LOG_STORAGE_METHOD)
         StateLog = self.get_model('StateLog')
 
         backend.setup_model(StateLog)

--- a/django_fsm_log/models.py
+++ b/django_fsm_log/models.py
@@ -2,7 +2,11 @@
 from __future__ import unicode_literals
 
 from django_fsm_log.conf import settings
-from django.contrib.contenttypes.fields import GenericForeignKey
+from django import VERSION as django_version
+if django_version < (1, 7):
+    from django.contrib.contenttypes.generic import GenericForeignKey
+else:
+    from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.encoding import force_text, python_2_unicode_compatible

--- a/django_fsm_log/models.py
+++ b/django_fsm_log/models.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django_fsm_log.conf import settings
-from django.contrib.contenttypes.generic import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.encoding import force_text, python_2_unicode_compatible


### PR DESCRIPTION
When running under Django 1.8, there were two warnings, I fixed those:

    /local/scratch/epolger/demand/demand-venv/lib/python2.7/site-packages/django_fsm_log/models.py:5: RemovedInDjango19Warning: django.contrib.contenttypes.generic is deprecated and will be removed in Django 1.9. Its contents have been moved to the fields, forms, and admin submodules of django.contrib.contenttypes.
      from django.contrib.contenttypes.generic import GenericForeignKey

    /local/scratch/epolger/demand/demand-venv/lib/python2.7/site-packages/django_fsm_log/apps.py:14: RemovedInDjango19Warning: import_by_path() has been deprecated. Use import_string() instead.
      backend = import_by_path(settings.DJANGO_FSM_LOG_STORAGE_METHOD)

The changes have been tested with TOX for python 2.7 and 3.4, with Django 1.6-1.8 (if needed, I can also send the `tox.ini` file I used in a separate PR).