### PR TITLE
Fixes for Django master/1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,17 @@ env:
     - TOX_ENV=py33-dj-1.6
     - TOX_ENV=py33-dj-1.7
     - TOX_ENV=py33-dj-1.8
-    - TOX_ENV=py33-dj-master
     - TOX_ENV=py34-dj-1.6
     - TOX_ENV=py34-dj-1.7
     - TOX_ENV=py34-dj-1.8
     - TOX_ENV=py34-dj-master
+    - TOX_ENV=py35-dj-master
 
 matrix:
     allow_failures:
         - env: TOX_ENV=py27-dj-master
-        - env: TOX_ENV=py33-dj-master
         - env: TOX_ENV=py34-dj-master
+        - env: TOX_ENV=py35-dj-master
 
 install:
     - pip install tox

--- a/django_fsm_log/backends.py
+++ b/django_fsm_log/backends.py
@@ -1,5 +1,4 @@
 from django_fsm_log.conf import settings
-from django.core.cache import get_cache
 
 
 class BaseBackend(object):
@@ -62,6 +61,12 @@ class SimpleBackend(object):
 
 
 if settings.DJANGO_FSM_LOG_STORAGE_METHOD == 'django_fsm_log.backends.CachedBackend':
-    cache = get_cache(settings.DJANGO_FSM_LOG_CACHE_BACKEND)
+    try:
+        from django.core.cache import caches
+    except ImportError:
+        from django.core.cache import get_cache  # Deprecated, removed in 1.9.
+        cache = get_cache(settings.DJANGO_FSM_LOG_CACHE_BACKEND)
+    else:
+        cache = caches[settings.DJANGO_FSM_LOG_CACHE_BACKEND]
 else:
     cache = None

--- a/django_fsm_log/models.py
+++ b/django_fsm_log/models.py
@@ -16,7 +16,6 @@ from django_fsm.signals import pre_transition, post_transition
 from django_fsm import FSMFieldMixin
 
 from .managers import StateLogManager
-from django.utils.module_loading import import_by_path
 
 
 @python_2_unicode_compatible
@@ -51,7 +50,8 @@ class StateLog(models.Model):
 
 try:
     import django.apps
-except: # django < 1.7
+except ImportError:  # Django < 1.7
+    from django.utils.module_loading import import_by_path
     backend = import_by_path(settings.DJANGO_FSM_LOG_STORAGE_METHOD)
     backend.setup_model(StateLog)
 


### PR DESCRIPTION
This PR contains two fixes to make django-fsm-log work with Django master (1.9).