### PR TITLE
Correct project url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='Logging for django-fsm',
     author='Gizmag',
     author_email='tech@gizmag.com',
-    url='https://github.com/gizmag/django_fsm_log',
+    url='https://github.com/gizmag/django-fsm-log',
     packages=find_packages(),
     install_requires=['django>=1.6', 'django_fsm>=2', 'django_appconf']
 )


### PR DESCRIPTION
There is an error in repo url in setup.py file. You might want to change it to match with the correct GitHub url.