### PR TITLE
Ignore logging for models in DJANGO_FSM_LOG_IGNORED_MODELS setting

### DIFF
--- a/django_fsm_log/backends.py
+++ b/django_fsm_log/backends.py
@@ -26,6 +26,8 @@ class CachedBackend(object):
     @staticmethod
     def pre_transition_callback(sender, instance, name, source, target, **kwargs):
         from .models import StateLog
+        if sender.__name__ in settings.DJANGO_FSM_LOG_IGNORED_MODELS:
+            return
         StateLog.pending_objects.create(
             by=getattr(instance, 'by', None),
             state=target,
@@ -52,6 +54,8 @@ class SimpleBackend(object):
     @staticmethod
     def post_transition_callback(sender, instance, name, source, target, **kwargs):
         from .models import StateLog
+        if sender.__name__ in settings.DJANGO_FSM_LOG_IGNORED_MODELS:
+            return
         StateLog.objects.create(
             by=getattr(instance, 'by', None),
             state=target,

--- a/django_fsm_log/conf.py
+++ b/django_fsm_log/conf.py
@@ -5,3 +5,4 @@ from appconf import AppConf
 class DjangoFSMLogConf(AppConf):
     STORAGE_METHOD = 'django_fsm_log.backends.SimpleBackend'
     CACHE_BACKEND = 'default'
+    IGNORED_MODELS = []

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,6 @@
 from unittest import skipIf
 from django.test import TestCase
+from django.conf import settings
 
 from django_fsm_log.models import StateLog
 from django_fsm_log.managers import PendingStateLogManager
@@ -96,6 +97,33 @@ class StateLogModelTests(TestCase):
 
         article = Article.objects.get(pk=self.article.pk)
         self.assertNotEqual(log.get_state_display(), article.get_state_display())
+
+
+class StateLogIgnoredModelTests(TestCase):
+    def setUp(self):
+        self.article = Article.objects.create(state='draft')
+        self.user = User.objects.create_user(username='jacob', password='password')
+        settings.DJANGO_FSM_LOG_IGNORED_MODELS = [Article.__name__]
+
+    def tearDown(self):
+        settings.DJANGO_FSM_LOG_IGNORED_MODELS = []
+
+    def test_log_not_created_if_model_ignored(self):
+        self.assertEqual(len(StateLog.objects.all()), 0)
+
+        self.article.submit()
+        self.article.save()
+
+        self.assertEqual(len(StateLog.objects.all()), 0)
+
+    def test_log_created_on_transition_when_model_not_ignored(self):
+        settings.DJANGO_FSM_LOG_IGNORED_MODELS = ['SomeOtherModel']
+        self.assertEqual(len(StateLog.objects.all()), 0)
+
+        self.article.submit()
+        self.article.save()
+
+        self.assertEqual(len(StateLog.objects.all()), 1)
 
 
 class StateLogManagerTests(TestCase):


### PR DESCRIPTION
Added a new setting IGNORED_MODELS; models included in this list will be ignored for FSM logging purposes. Added some tests.
This addresses issue #19.