### PR TITLE
Ignore logging for models in DJANGO_FSM_LOG_IGNORED_MODELS setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ StateLog.objects.all()
 # ...all recorded logs...
 ```
 
+### Disabling logging for specific models
+
+By default transitions are logged for all models. Logging can be disabled for
+specific models by adding their fully qualified name to `DJANGO_FSM_LOG_IGNORED_MODELS`.
+
+```python
+DJANGO_FSM_LOG_IGNORED_MODELS = ('poll.models.Vote')
+```
+
 ### `for_` Manager Method
 
 For convenience there is a custom `for_` manager method to easily filter on the generic foreign key

--- a/django_fsm_log/backends.py
+++ b/django_fsm_log/backends.py
@@ -15,6 +15,11 @@ class BaseBackend(object):
     def post_transition_callback(*args, **kwargs):
         raise NotImplementedError
 
+    @staticmethod
+    def _get_model_qualified_name__(sender):
+        return '%s.%s' % (sender.__module__,
+                          getattr(sender, '__qualname__', sender.__name__))
+
 
 class CachedBackend(object):
 
@@ -26,6 +31,10 @@ class CachedBackend(object):
     @staticmethod
     def pre_transition_callback(sender, instance, name, source, target, **kwargs):
         from .models import StateLog
+
+        if BaseBackend._get_model_qualified_name__(sender) in settings.DJANGO_FSM_LOG_IGNORED_MODELS:
+            return
+
         StateLog.pending_objects.create(
             by=getattr(instance, 'by', None),
             state=target,
@@ -52,6 +61,10 @@ class SimpleBackend(object):
     @staticmethod
     def post_transition_callback(sender, instance, name, source, target, **kwargs):
         from .models import StateLog
+
+        if BaseBackend._get_model_qualified_name__(sender) in settings.DJANGO_FSM_LOG_IGNORED_MODELS:
+            return
+
         StateLog.objects.create(
             by=getattr(instance, 'by', None),
             state=target,

--- a/django_fsm_log/conf.py
+++ b/django_fsm_log/conf.py
@@ -5,3 +5,4 @@ from appconf import AppConf
 class DjangoFSMLogConf(AppConf):
     STORAGE_METHOD = 'django_fsm_log.backends.SimpleBackend'
     CACHE_BACKEND = 'default'
+    IGNORED_MODELS = []


### PR DESCRIPTION
Version of  #29 by @timb07.

The fully qualified name is used to prevent model name conflicts across applications.

Addresses #19 