### PR TITLE
Use `model_class` instead of retrieving the whole object in FSMLog

### DIFF
--- a/django_fsm_log/models.py
+++ b/django_fsm_log/models.py
@@ -42,8 +42,8 @@ class StateLog(models.Model):
         )
 
     def get_state_display(self):
-        fsm_obj = self.content_object
-        for field in fsm_obj._meta.fields:
+        fsm_cls = self.content_type.get_model_class()
+        for field in fsm_cls._meta.fields:
             if isinstance(field, FSMFieldMixin):
                 state_display = dict(field.flatchoices).get(self.state, self.state)
                 return force_text(state_display, strings_only=True)

--- a/django_fsm_log/models.py
+++ b/django_fsm_log/models.py
@@ -42,7 +42,7 @@ class StateLog(models.Model):
         )
 
     def get_state_display(self):
-        fsm_cls = self.content_type.get_model_class()
+        fsm_cls = self.content_type.model_class()
         for field in fsm_cls._meta.fields:
             if isinstance(field, FSMFieldMixin):
                 state_display = dict(field.flatchoices).get(self.state, self.state)


### PR DESCRIPTION
All we need is the actual model class, fetching the whole relation is a bit wasteful.