### PR TITLE
Don't fail if a log attribute is not set.

### DIFF
--- a/django_fsm_log/helpers.py
+++ b/django_fsm_log/helpers.py
@@ -12,7 +12,10 @@ class FSMLogDescriptor(object):
             self.set(value)
 
     def get(self):
-        return getattr(self.instance, self.ATTR_PREFIX + self.attribute)
+        try:
+            return getattr(self.instance, self.ATTR_PREFIX + self.attribute)
+        except AttributeError:
+            return None
 
     def set(self, value):
         setattr(self.instance, self.ATTR_PREFIX + self.attribute, value)


### PR DESCRIPTION
Prevents AttributeError being thrown from `description.get()` calls when allow_inline=True

edit: I'm not sure how this many tests failed from the change. How do I fix this?