### PR TITLE
Do not log transitions if target is None

### DIFF
--- a/django_fsm_log/backends.py
+++ b/django_fsm_log/backends.py
@@ -7,6 +7,9 @@ def _pre_transition_callback(sender, instance, name, source, target, manager, **
     if BaseBackend._get_model_qualified_name__(sender) in settings.DJANGO_FSM_LOG_IGNORED_MODELS:
         return
 
+    if target is None:
+        return
+
     values = {
         'state': target,
         'transition': name,

--- a/tests/models.py
+++ b/tests/models.py
@@ -43,6 +43,11 @@ class Article(models.Model):
     def submit_inline_description_change(self, change_to, description=None, by=None):
         description.set(change_to)
 
+    @fsm_log_by
+    @transition(field=state, source='draft', target=None)
+    def validate_draft(self, by=None):
+        pass
+
 
 class ArticleInteger(models.Model):
     STATE_ONE = 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,11 +6,11 @@ from .models import Article, ArticleInteger
 
 
 def test_get_available_state_transitions(article):
-    assert len(list(article.get_available_state_transitions())) == 3
+    assert len(list(article.get_available_state_transitions())) == 4
 
 
 def test_get_all_state_transitions(article):
-    assert len(list(article.get_all_state_transitions())) == 5
+    assert len(list(article.get_all_state_transitions())) == 6
 
 
 def test_log_created_on_transition(article):
@@ -27,6 +27,14 @@ def test_log_not_created_if_transition_fails(article):
 
     with pytest.raises(TransitionNotAllowed):
         article.publish()
+
+    assert len(StateLog.objects.all()) == 0
+
+
+def test_log_not_created_if_target_is_none(article):
+    assert len(StateLog.objects.all()) == 0
+
+    article.validate_draft()
 
     assert len(StateLog.objects.all()) == 0
 


### PR DESCRIPTION
target=None is meant to only validate the source state.  This should not
get logged, and currently fails even:

> django.db.utils.IntegrityError: NOT NULL constraint failed: django_fsm_log_statelog.state