### PR TITLE
tests: add "testing" extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,14 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=['django>=1.8', 'django_fsm>=2', 'django_appconf'],
+    extras_require={
+        'testing': [
+            'pytest',
+            'pytest-cov',
+            'pytest-django',
+            'pytest-mock',
+        ],
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,8 @@ envlist =
 [testenv]
 usedevelop = true
 commands = pytest --cov=django_fsm_log --cov=tests {posargs}
+extras = testing
 deps =
-    pytest
-    pytest-cov
-    pytest-django
-    pytest-mock
     dj-1.8: Django>=1.8,<1.9
     dj-1.11: Django>=1.11,<2.0
     dj-2.0: Django>=2.0,<2.1
@@ -21,5 +18,6 @@ deps =
 [testenv:flake8]
 basepython = python3.6
 commands = flake8 django_fsm_log tests
+extras =
 deps =
     flake8


### PR DESCRIPTION
This lists the dependencies for tests in setup.py, and allows for `pip
install -e '.[testing]'` to easily install them.