### PR TITLE
admin: StateLogInline: has_add_permission django 2.1 compatibility

### DIFF
--- a/django_fsm_log/admin.py
+++ b/django_fsm_log/admin.py
@@ -11,7 +11,7 @@ class StateLogInline(GenericTabularInline):
     model = StateLog
     can_delete = False
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj):
         return False
 
     def has_change_permission(self, request, obj=None):

--- a/django_fsm_log/admin.py
+++ b/django_fsm_log/admin.py
@@ -11,7 +11,7 @@ class StateLogInline(GenericTabularInline):
     model = StateLog
     can_delete = False
 
-    def has_add_permission(self, request, obj):
+    def has_add_permission(self, request, obj=None):
         return False
 
     def has_change_permission(self, request, obj=None):


### PR DESCRIPTION
admin: StateLogInline: has_add_permission add obj parameter for django 2.1 compatibility (django/contrib/admin/options.py:InlineModelAdmin:has_add_permission (2116 line))

may do ```obj=None``` for backward compatibility