### PR TITLE
Revert "Solve warning coming from django 4.0"

### DIFF
--- a/django_fsm_log/apps.py
+++ b/django_fsm_log/apps.py
@@ -9,7 +9,6 @@ from django_fsm.signals import pre_transition, post_transition
 class DjangoFSMLogAppConfig(AppConfig):
     name = 'django_fsm_log'
     verbose_name = "Django FSM Log"
-    default_auto_field = 'django.db.models.BigAutoField'
 
     def ready(self):
         backend = import_string(settings.DJANGO_FSM_LOG_STORAGE_METHOD)


### PR DESCRIPTION
Reverts gizmag/django-fsm-log#107

this warning, could be solved at project level by configuring the `DEFAULT_AUTO_FIELD` setting.